### PR TITLE
fix: Remove default for `flutterVersion`

### DIFF
--- a/.github/workflows/build_android.yaml
+++ b/.github/workflows/build_android.yaml
@@ -35,7 +35,7 @@ on:
       flutterVersion:
         required: false
         type: string
-        default: stable
+        
     secrets:
       additionalBuildArguments:
         required: false

--- a/.github/workflows/build_ios.yaml
+++ b/.github/workflows/build_ios.yaml
@@ -30,7 +30,7 @@ on:
       flutterVersion:
         required: false
         type: string
-        default: stable
+        
     secrets:
       additionalBuildArguments:
         required: false

--- a/.github/workflows/melos_quality_checks.yaml
+++ b/.github/workflows/melos_quality_checks.yaml
@@ -24,7 +24,6 @@ on:
       flutterVersion:
         required: false
         type: string
-        default: stable
 
 jobs:
   quality:


### PR DESCRIPTION
Having this as stable actually breaks as `stable` is a channel and not a version. Removing the default works and has the expected result of using the most recent flutter version. I guess it could be considered to eventually add an optional `flutterChannel` argument however that should only be done once it actually is needed.

Closes #9 